### PR TITLE
Fix stray log error on first run before the prefix exists

### DIFF
--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -10,8 +10,11 @@ export WINEARCH="win64"
 export WINEDLLOVERRIDES="mscoree=" # Disable Mono installation
 
 log_message() {
-    # The log file lives inside the Wine prefix, which does not exist yet on the
-    # very first run; tolerate that rather than spewing "No such file" errors.
+    # The log file lives inside the Wine prefix, which does not exist on the very
+    # first run. Skip logging until its directory exists - a trailing 2>/dev/null
+    # does NOT suppress the error, because bash reports the failed >> redirection
+    # before it applies the stderr redirect.
+    [ -d "$(dirname "$log_file")" ] || return 0
     echo "$(date): $1" >> "$log_file" 2>/dev/null
 }
 


### PR DESCRIPTION
## Summary
- `log_message()` appends to a log file inside the Wine prefix and relied on a trailing `2>/dev/null` to stay silent on the very first run (before the prefix exists). That doesn't work: bash reports the failed `>>` redirection **before** it applies the stderr redirect, so a fresh-prefix first boot still leaked `/startapp.sh: line 15: .../backblaze-wine-startapp.log: No such file or directory` into the container logs.
- Guard on the log directory existing instead, so logging is simply skipped until the prefix is created.

Cosmetic only — no change to backup behaviour.

## Test plan
- [ ] CI builds the image
- [ ] On a fresh prefix (no existing `/config/wine`), first-boot logs no longer show the `line 15 ... No such file or directory` error
- [ ] Normal runs (prefix already present) still write to the startup log as before