### PR TITLE
Create bzbui skin-asset aliases so the GUI renders on first launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Still please be attentive during the install process: The docker by design has r
 
 ## Known Limitations
 
-Backblaze 10.x (64-bit, Windows 10-only) installs, signs in, and backs up reliably under Wine, but two cosmetic quirks remain. **Neither affects your backups:**
+Backblaze 10.x (64-bit, Windows 10-only) installs, signs in, and backs up reliably under Wine. One cosmetic quirk remains, and it does **not** affect your backups:
 
-- **The control panel renders dark / unstyled.** Backblaze draws its UI with custom GDI+ code that Wine doesn't fully reproduce, so the control-panel window has a black background and the warning dialogs show no body text. The UI is still usable — buttons and input fields work, so you can sign in, choose what to back up, and change settings. (Investigated and ruled out: the Windows colour palette, window-manager modes, the virtual-desktop toggle, `winehq-staging`, and native `gdiplus` — it's a Wine/Backblaze rendering incompatibility, not a setting we can flip.)
 - **"Permission Issue … `bzdata\bzreports`" warning.** A false positive: Backblaze's permission self-check misbehaves under Wine, but it writes to that directory fine and backups run normally. Safe to ignore.
+
+> The control panel previously rendered unstyled (black background, blank dialog text). That turned out **not** to be an unfixable GDI+ incompatibility: `bzbui.exe` references its hi-DPI skin assets with hyphenated names (`*-4x.gif`) while the bypass install ships them underscored (`*_4x.gif`), so the skin failed to load and the main window couldn't build. The container now creates the hyphen-named aliases at startup, so the panel renders correctly on first launch.
 
 ## Docker Images
 ### Content

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -156,7 +156,29 @@ fetch_and_install() {
 
 }
 
+# Backblaze's bzbui.exe references its high-DPI skin assets with hyphenated names
+# (e.g. "bzbui_skin_bg-4x.gif", "windows-computer-4x_dm.gif"), but the installer
+# payload ships them with underscores ("bzbui_skin_bg_4x.gif"). Without the
+# hyphen-named copies bzbui cannot build its main control-panel window - it
+# renders unstyled and logs "could not CreateDialog for main white window". The
+# naming differs across asset families (some flip every "_", some only the one
+# before "4x"), so rather than guess we read the exact names the binaries
+# reference and alias each from its underscore twin - the rule is reliable: the
+# wanted name with every "-" turned back into "_" is the file already on disk.
+# Deriving the list from the binaries keeps it complete across client versions,
+# so the GUI renders correctly on the first launch with no per-file chasing.
+create_skin_aliases() {
+    bb_dir="${WINEPREFIX}drive_c/Program Files/Backblaze"
+    [ -d "$bb_dir" ] || return 0
+    grep -aohE '[A-Za-z0-9_-]+-4x[A-Za-z0-9_]*\.gif' "$bb_dir"/*.exe "$bb_dir"/*.dll 2>/dev/null \
+        | sort -u | while read -r want; do
+            have="$(printf '%s' "$want" | tr '-' '_')"
+            [ -f "$bb_dir/$have" ] && [ ! -e "$bb_dir/$want" ] && cp -- "$bb_dir/$have" "$bb_dir/$want"
+        done
+}
+
 start_app() {
+    create_skin_aliases
     log_message "STARTAPP: Starting Backblaze version $(cat "$local_version_file")"
     wine "${WINEPREFIX}drive_c/Program Files/Backblaze/bzbui.exe" -noquiet &
     sleep infinity


### PR DESCRIPTION
## Summary
`bzbui.exe` references its hi-DPI skin assets with **hyphenated** names (`bzbui_skin_bg-4x.gif`, `windows-computer-4x_dm.gif`), but the MSI-bypass install ships them **underscored** (`bzbui_skin_bg_4x.gif`). With the names mismatched the skin can't load, so `bzbui` fails to build its main window (`could not CreateDialog for main white window`) — the control panel renders unstyled and the install self-check warns.

- Add `create_skin_aliases()`, called from `start_app` **before** `bzbui` launches. It greps the exact `-4x` asset names out of the binaries (`*.exe`/`*.dll`) and copies each from its underscore twin — the rule is reliable: *the wanted name with every `-` turned back into `_` is the file already on disk*.
- Deriving the list from the binaries makes it **complete across client versions** (no hardcoded list, no per-file chasing). It's idempotent and runs every start, so it also survives client auto-updates.
- Reclassify the "control panel renders dark / unstyled" entry in **Known Limitations** as resolved (this was its real cause).

## Test plan
- [ ] CI builds the image
- [ ] **Fresh install** on Unraid: after `bzdoinstall` completes, `bzbui` renders on the **first launch** with a correctly-styled (white) control panel — no `could not read …-4x.gif` or `could not CreateDialog` in `bzbui*.log`
- [ ] The `should exist but does not` sanity-check entries do **not** recur (no iterative re-runs needed)
- [ ] **Existing install**: aliases are created on next start; no regression
- [ ] Confirm `grep -aohE '[A-Za-z0-9_-]+-4x[A-Za-z0-9_]*\.gif' "$bb_dir"/*.exe` actually returns the asset names on the target client build