### PR TITLE
Add rundll32 supportedOS manifest for self-updates, plus Known-Limitations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Backblaze 10.x (64-bit, Windows 10-only) installs, signs in, and backs up reliab
 
 > The control panel previously rendered unstyled (black background, blank dialog text). That turned out **not** to be an unfixable GDI+ incompatibility: `bzbui.exe` references its hi-DPI skin assets with hyphenated names (`*-4x.gif`) while the bypass install ships them underscored (`*_4x.gif`), so the skin failed to load and the main window couldn't build. The container now creates the hyphen-named aliases at startup, so the panel renders correctly on first launch.
 
+> Backblaze's installer — and, more importantly, its in-app **self-update** — runs a .NET MSI custom action (`CheckVersions`) inside `rundll32.exe`. Under Wine's Windows 8.1+ "version lie", an *unmanifested* process is told it is running Windows 8 (6.2) regardless of what the registry reports, so that check aborts with `MajorVerTooOld` / "unsupported OS" even though the prefix is forced to Windows 10. The first install sidesteps this by bypassing the MSI (it drives `bzdoinstall.exe` directly), but a self-update runs the MSI itself. The container therefore writes an external `rundll32.exe.manifest` declaring a Windows 10/11 `supportedOS` into `system32` and `syswow64` at startup and enables `PreferExternalManifest`, so `GetVersionEx` reports the real version and self-updates do not break on the OS gate.
+
 ## Docker Images
 ### Content
 Here are the main components of this image:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Still please be attentive during the install process: The docker by design has r
 
 ## Known Limitations
 
-Backblaze 10.x (64-bit, Windows 10-only) installs, signs in, and backs up reliably under Wine. One cosmetic quirk remains, and it does **not** affect your backups:
+Backblaze 10.x (64-bit, Windows 10-only) installs, signs in, and backs up reliably under Wine. Two caveats are worth knowing — neither corrupts or blocks your backups:
+
+- **Upload speed is limited by Backblaze-on-Wine, not the container or your network.** An `iperf3` test from inside the container reaches full line speed, so the bottleneck is the Backblaze client itself: the 10.x upload path is several times slower *per thread* under Wine than the old 9.x client, and Backblaze's heuristic for spawning more upload threads misreads an idle box and under-spawns. **Raising the thread count** under Settings → Performance helps a lot — the work is network-wait-bound, so over-subscribing threads well beyond your CPU core count is fine here (the usual "stay under your core count" advice is for native machines and does not apply). Throughput is also far lower while grinding through many small files than on large ones, so expect it to climb as the backup progresses. See upstream [#212](https://github.com/JonathanTreffler/backblaze-personal-wine-container/issues/212) for details and a community workaround (adding CPU load to coax Backblaze into spawning more upload threads).
 
 - **"Permission Issue … `bzdata\bzreports`" warning.** A false positive: Backblaze's permission self-check misbehaves under Wine, but it writes to that directory fine and backups run normally. Safe to ignore.
 

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -52,16 +52,58 @@ force_windows_10() {
     wine reg add "$nt_key" /v ProductName               /t REG_SZ    /d 'Microsoft Windows 10' /f
     wine reg add "$nt_key" /v CurrentMajorVersionNumber /t REG_DWORD /d 10 /f
     wine reg add "$nt_key" /v CurrentMinorVersionNumber /t REG_DWORD /d 0  /f
+    # Defeat the Windows 8.1+ GetVersionEx "version lie": an *unmanifested* process
+    # is told 6.2 (Windows 8) regardless of the keys set above. Telling Wine to
+    # prefer an external manifest lets the rundll32.exe.manifest written by
+    # install_supportedos_manifest() declare a Windows 10/11 supportedOS, so the
+    # .NET "CheckVersions" action Backblaze runs inside rundll32 sees the real 10.0.
+    wine reg add 'HKLM\Software\Microsoft\Windows\CurrentVersion\SideBySide' /v PreferExternalManifest /t REG_DWORD /d 1 /f
     # Do NOT "wineserver -w" here. reg writes are synchronous, and once Backblaze
     # is installed the first wine call auto-starts its persistent bzserv service -
     # waiting for the server to terminate would then block forever and the GUI
     # (bzbui.exe) would never launch.
 }
 
+# Backblaze runs a .NET MSI custom action ("CheckVersions") inside rundll32.exe -
+# during a normal MSI install and, crucially for us, during its own in-app
+# self-update. Thanks to the Windows 8.1+ "version lie", that unmanifested
+# rundll32 is told Windows 8 (6.2) and the action aborts with "MajorVerTooOld" /
+# "unsupported OS", even though force_windows_10() set the prefix to 10.0. We drop
+# an external manifest declaring a Windows 10/11 supportedOS into both system
+# dirs; together with the PreferExternalManifest key set in force_windows_10(),
+# GetVersionEx then returns the real 10.0. Our installer bypasses the MSI so this
+# is not needed for the first install, but it keeps Backblaze's self-update from
+# breaking on the OS gate once it ships a version newer than the installed one.
+# (Mirrors upstream's assets/rundll32.exe.manifest, written at runtime so the fix
+# stays self-contained in this script instead of a baked image template.)
+install_supportedos_manifest() {
+    for d in system32 syswow64; do
+        dir="${WINEPREFIX}drive_c/windows/${d}"
+        [ -d "$dir" ] || continue
+        cat > "$dir/rundll32.exe.manifest" <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10/11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    </application>
+  </compatibility>
+</assembly>
+EOF
+        log_message "WINE: installed rundll32 supportedOS manifest into ${d}"
+    done
+}
+
 echo "WINE: binary=$(command -v wine) version=$(wine --version 2>/dev/null)"
 echo "WINE: WINEARCH=${WINEARCH} WINEPREFIX=${WINEPREFIX}"
 echo "WINE: forcing reported Windows version to Windows 10"
 force_windows_10
+install_supportedos_manifest
 echo "WINE: OS version now reported by the prefix:"
 wine cmd /c ver 2>/dev/null | tr -d '\r'
 log_message "WINE: prefix ready and reporting Windows 10"


### PR DESCRIPTION
This PR has two parts: a small **code fix** (the self-update OS-manifest) and two **documentation** notes added to the README's Known Limitations.

---

## Code: rundll32 supportedOS manifest

Ports upstream commit JonathanTreffler/backblaze-personal-wine-container@055496b into this fork, adapted to our **runtime** prefix model.

- Adds `PreferExternalManifest` (`HKLM\...\CurrentVersion\SideBySide`) inside `force_windows_10()`.
- New `install_supportedos_manifest()` writes an external `rundll32.exe.manifest` (Win10/11 `supportedOS`, same GUIDs as upstream) into `system32` **and** `syswow64` on every start (idempotent), called right after `force_windows_10`.

Generated at runtime in `startapp.sh` rather than baked into a `/defaults` template — this fork builds the prefix at runtime and has no template prefix.

### Why

Backblaze runs a .NET MSI custom action (`CheckVersions`) inside `rundll32.exe` during its **in-app self-update**. The Windows 8.1+ "version lie" reports 6.2 (Windows 8) to that *unmanifested* process, so it aborts with `MajorVerTooOld` / "unsupported OS" even though `force_windows_10()` sets the prefix to 10.0. The external manifest + `PreferExternalManifest` defeat the lie so `GetVersionEx` returns the real 10.0.

Our installer bypasses the MSI (runs `bzdoinstall.exe` directly), so this is **not** needed for a fresh install — it's insurance so Backblaze's self-update doesn't break on the OS gate once a version newer than the installed one ships.

### Risk / scope

Additive and low-risk. `PreferExternalManifest` is global, but `rundll32` is the only binary given an external manifest; the Backblaze binaries keep their embedded manifests. No change to the current install/run path.

### Testing

CI builds this PR image (not pushed to `:latest`). On the Unraid NAS, restart with the PR image and confirm:

- Container starts and keeps uploading normally (no regression).
- `rundll32.exe.manifest` exists in both `drive_c/windows/system32` and `syswow64`.
- `PreferExternalManifest` reg key returns `0x1`.

A from-scratch install should behave identically (the manifest is inert during the MSI-bypass install).

---

## Docs: Known Limitations

Two notes added to the README's **Known Limitations** section, documenting real Backblaze-on-Wine behaviour for end users:

- **Self-update OS gate** — the rationale behind the manifest fix above (why a self-update can hit "unsupported OS" and how the container handles it).
- **Upload-speed limitation** — `iperf3` from inside the container proves the bottleneck is the Backblaze client, not the container/network; the 10.x per-thread upload path is slower under Wine and Backblaze's thread-spawn heuristic under-spawns on an idle box. Raising the thread count helps (over-subscription is fine for this network-wait-bound workload). Links upstream #212.

Docs-only; no image impact.
