### PR TITLE
Dual-LTS variants: Ubuntu 24.04 + 26.04, base refresh (v10.1.0)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dockerfile: [ubuntu24]
+        # ubuntu24 is the default (oldest supported LTS); the shared :latest/:main/
+        # version tags track it for stability. ubuntu26 ships as :ubuntu26 for early
+        # validation before it becomes the default. When 24.04's support ends, drop
+        # its entry here and let the default fall through to the next-oldest LTS.
+        dockerfile: [ubuntu24, ubuntu26]
 
     steps:
       - name: Checkout repository
@@ -62,23 +66,27 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # :latest only moves on a release-tag push (e.g. v10.0.0), so a routine
-          # main build or the weekly cron no longer overwrites it. main/ubuntu24
-          # track the branch builds; the version tag is published on tag pushes.
+          # Each variant always gets its own :ubuntuNN tag. The shared, unsuffixed
+          # tags (:latest, :main, the version tag) belong to the DEFAULT variant
+          # only - the oldest supported LTS (ubuntu24) - so they stay stable and the
+          # two matrix jobs never clobber each other's tags. :latest only moves on a
+          # release-tag push. The newer LTS is reachable via :ubuntu26 (and
+          # :<version>-ubuntu26 on releases) for early validation.
           tags: |
-            type=ref,event=tag
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=ubuntu24
+            type=raw,value=${{ matrix.dockerfile }}
+            type=ref,event=tag,enable=${{ matrix.dockerfile == 'ubuntu24' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && matrix.dockerfile == 'ubuntu24' }}
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' && matrix.dockerfile == 'ubuntu24' }}
+            type=ref,event=tag,suffix=-ubuntu26,enable=${{ matrix.dockerfile == 'ubuntu26' }}
 
       # Set up cache
       - name: Setup Docker build cache
         uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.dockerfile }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ matrix.dockerfile }}-
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.1.0] - 2026-06-20
+
 ### Added
 - Ubuntu 26.04 LTS ("Resolute") image, published as the `ubuntu26` tag (and
   `vX.Y.Z-ubuntu26` on releases). It ships alongside the default Ubuntu 24.04
@@ -155,5 +157,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated Dependencies
 
-[Unreleased]: https://github.com/iamfoz/backblaze-64-personal-wine-container/compare/v10.0.0...HEAD
+[Unreleased]: https://github.com/iamfoz/backblaze-64-personal-wine-container/compare/v10.1.0...HEAD
+[10.1.0]: https://github.com/iamfoz/backblaze-64-personal-wine-container/compare/v10.0.0...v10.1.0
 [10.0.0]: https://github.com/iamfoz/backblaze-64-personal-wine-container/releases/tag/v10.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Ubuntu 26.04 LTS ("Resolute") image, published as the `ubuntu26` tag (and
+  `vX.Y.Z-ubuntu26` on releases). It ships alongside the default Ubuntu 24.04
+  image as an early-access variant so problems can be found before it becomes
+  the default. The project now tracks the two most recent Ubuntu LTS releases:
+  the older is the default (`latest`) for stability, the newer is offered early,
+  and the oldest is retired when it reaches end of support.
+
+### Changed
+- Updated the jlesage GUI base image to `v4.12.5` on both LTS variants.
+- The WineHQ signing key is now stored as an armored `.asc` keyring referenced by
+  an inline deb822 source, so the repository verifies under the stricter apt in
+  Ubuntu 26.04 (which ignores a keyring saved with the old `.key` extension).
+- CI builds both LTS variants in a matrix. The shared `latest` / `main` / version
+  tags track the default (oldest supported) LTS; the newer LTS is published under
+  its own `ubuntuNN` tag.
+
 ## [10.0.0] - 2026-06-05
 
 ### Changed

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -27,6 +27,10 @@ LABEL net.unraid.docker.webui="http://[IP]:[PORT:5800]/" \
 #     newer release ships. We track winehq-stable (currently Wine 11.x).
 #   * deb822 + a keyring file is reliable; the old apt-key / add-apt-repository
 #     approach silently fell back to Ubuntu's ancient Wine 6.x when it broke.
+#   * Save the key with a .asc (armored) extension and write our own deb822
+#     stanza pointing Signed-By at it. Newer apt (26.04+) ignores keyrings with
+#     an unrecognised ".key" extension, which leaves the repo unsigned; an inline
+#     stanza also avoids depending on the exact name of WineHQ's .sources file.
 #   * Backblaze 10.x is 64-bit only, but winehq-stable still pulls its i386
 #     WoW64 libraries via recommends. That is harmless and kept for safety.
 # Installing Wine on the jlesage 24.04 base needs three adjustments:
@@ -55,9 +59,9 @@ RUN mkdir -p /config/log /tmp/run && \
     dpkg --add-architecture i386 && \
     mkdir -pm755 /etc/apt/keyrings && \
     curl -fsSL https://dl.winehq.org/wine-builds/winehq.key \
-        -o /etc/apt/keyrings/winehq-archive.key && \
-    curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources \
-        -o /etc/apt/sources.list.d/winehq-noble.sources && \
+        -o /etc/apt/keyrings/winehq-archive.asc && \
+    printf 'Types: deb\nURIs: https://dl.winehq.org/wine-builds/ubuntu\nSuites: noble\nComponents: main\nSigned-By: /etc/apt/keyrings/winehq-archive.asc\n' \
+        > /etc/apt/sources.list.d/winehq.sources && \
     apt-get update && \
     apt-get install -y --no-install-recommends winehq-stable \
         libgnutls30t64 libfreetype6 libfontconfig1 libpng16-16t64 \

--- a/Dockerfile.ubuntu26
+++ b/Dockerfile.ubuntu26
@@ -27,6 +27,10 @@ LABEL net.unraid.docker.webui="http://[IP]:[PORT:5800]/" \
 #     newer release ships. We track winehq-stable (currently Wine 11.x).
 #   * deb822 + a keyring file is reliable; the old apt-key / add-apt-repository
 #     approach silently fell back to Ubuntu's ancient Wine 6.x when it broke.
+#   * Save the key with a .asc (armored) extension and write our own deb822
+#     stanza pointing Signed-By at it. Newer apt (26.04+) ignores keyrings with
+#     an unrecognised ".key" extension, which leaves the repo unsigned; an inline
+#     stanza also avoids depending on the exact name of WineHQ's .sources file.
 #   * Backblaze 10.x is 64-bit only, but winehq-stable still pulls its i386
 #     WoW64 libraries via recommends. That is harmless and kept for safety.
 # Installing Wine on the jlesage 26.04 base needs three adjustments:
@@ -55,9 +59,9 @@ RUN mkdir -p /config/log /tmp/run && \
     dpkg --add-architecture i386 && \
     mkdir -pm755 /etc/apt/keyrings && \
     curl -fsSL https://dl.winehq.org/wine-builds/winehq.key \
-        -o /etc/apt/keyrings/winehq-archive.key && \
-    curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/resolute/winehq-resolute.sources \
-        -o /etc/apt/sources.list.d/winehq-resolute.sources && \
+        -o /etc/apt/keyrings/winehq-archive.asc && \
+    printf 'Types: deb\nURIs: https://dl.winehq.org/wine-builds/ubuntu\nSuites: resolute\nComponents: main\nSigned-By: /etc/apt/keyrings/winehq-archive.asc\n' \
+        > /etc/apt/sources.list.d/winehq.sources && \
     apt-get update && \
     apt-get install -y --no-install-recommends winehq-stable \
         libgnutls30t64 libfreetype6 libfontconfig1 libpng16-16t64 \

--- a/Dockerfile.ubuntu26
+++ b/Dockerfile.ubuntu26
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:ubuntu-24.04-v4.12.5@sha256:6973f57dd1848105cacf769f4dfefecd73ece16c166ba93f9ab63ab26fb204b7
+FROM jlesage/baseimage-gui:ubuntu-26.04-v4.12.5@sha256:cb60251a123ab73847f77d713c15f30fb0d131090bc0aaa7e6fd8903ecb37fe1
 
 ENV WINEPREFIX=/config/wine/
 # Backblaze 10.x is a native 64-bit app, so the prefix must be win64.
@@ -29,7 +29,7 @@ LABEL net.unraid.docker.webui="http://[IP]:[PORT:5800]/" \
 #     approach silently fell back to Ubuntu's ancient Wine 6.x when it broke.
 #   * Backblaze 10.x is 64-bit only, but winehq-stable still pulls its i386
 #     WoW64 libraries via recommends. That is harmless and kept for safety.
-# Installing Wine on the jlesage 24.04 base needs three adjustments:
+# Installing Wine on the jlesage 26.04 base needs three adjustments:
 #
 # 1. Its build-time environment is minimal - /run and the user/group database
 #    do not exist yet - so postinst scripts that take locks or create users
@@ -56,8 +56,8 @@ RUN mkdir -p /config/log /tmp/run && \
     mkdir -pm755 /etc/apt/keyrings && \
     curl -fsSL https://dl.winehq.org/wine-builds/winehq.key \
         -o /etc/apt/keyrings/winehq-archive.key && \
-    curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources \
-        -o /etc/apt/sources.list.d/winehq-noble.sources && \
+    curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/resolute/winehq-resolute.sources \
+        -o /etc/apt/sources.list.d/winehq-resolute.sources && \
     apt-get update && \
     apt-get install -y --no-install-recommends winehq-stable \
         libgnutls30t64 libfreetype6 libfontconfig1 libpng16-16t64 \

--- a/README.md
+++ b/README.md
@@ -83,11 +83,22 @@ Here are the main components of this image:
 
 | Tag | Description |
 |-----|-------------|
-| latest | Latest stable build (Ubuntu 24.04) |
-| ubuntu24 | Same as `latest` (Ubuntu 24.04) |
+| latest | Recommended stable image — the current default LTS (Ubuntu 24.04) |
+| ubuntu24 | Ubuntu 24.04 LTS build (same image as `latest`) |
+| ubuntu26 | Ubuntu 26.04 LTS build — early-access, for hardening before it becomes the default |
 | main | Automatic build of the `main` branch (may be unstable) |
+| vX.Y.Z | A specific release (Ubuntu 24.04); `vX.Y.Z-ubuntu26` for the 26.04 variant |
 
-Only the Ubuntu 24.04 LTS image is built. The older `ubuntu22` / `ubuntu20` / `ubuntu18` variants are no longer published.
+**LTS policy.** The image tracks the **two most recent Ubuntu LTS releases** at a
+time. The **older** of the two is the default (`latest`), chosen for stability;
+the **newer** ships alongside (currently `ubuntu26`) so problems can be found and
+fixed before it ever becomes the default. Interim bugfixes and base/runtime
+uplifts are released against both as they land. When an LTS reaches end of
+support it is retired — the newer LTS becomes the new default and the next LTS is
+added as the early-access variant. So `latest` always points at a mature,
+well-supported LTS, while the newer-LTS tag lets you opt in early if you want it.
+
+The older `ubuntu22` / `ubuntu20` / `ubuntu18` variants are no longer published.
 
 ### Platforms
 


### PR DESCRIPTION
Adds an Ubuntu 26.04 LTS variant alongside the existing 24.04 one and refreshes the bases. Target release: v10.1.0.

## Changes
- **`Dockerfile.ubuntu26`** (new): jlesage `ubuntu-26.04-v4.12.5` base, WineHQ `resolute` repo. Otherwise identical to ubuntu24.
- **`Dockerfile.ubuntu24`**: base bumped to `ubuntu-24.04-v4.12.5`.
- **WineHQ keyring**: now an armored `.asc` keyring with an inline deb822 source, so the repo verifies under 26.04's stricter apt (which ignores a `.key`-named keyring). Applied to both, works on noble too.
- **CI**: matrix builds both variants; shared `:latest`/`:main`/version tags track the default (oldest LTS, 24.04), 26.04 publishes as `:ubuntu26` (+ `:<version>-ubuntu26`); per-variant cache key.
- **Docs**: README Tags section + rolling two-LTS policy; CHANGELOG stamped v10.1.0.

## Validation
Both variants built and smoke-tested on amd64 (fozdock): ubuntu26 installs and runs Backblaze fine. Policy: track the two newest LTS releases — older is the stable default, newer is early-access, oldest retired at end of support.