### PR TITLE
Detect the stale-lock respawn loop and gate lock repair on process age

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: python3 tests/test-sanitiser.py
       - name: Test stall detection fails safe
         run: bash tests/test-health.sh
+      - name: Test the doctor's lock repair gate
+        run: bash tests/test-doctor.sh
 
   build:
     needs: sanitiser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into and, with `--fix`, repairs the ones that can be repaired safely (reported Windows
   version, drive links, control panel skin aliases, a stale four-hour lock). Repairs are
   idempotent, never touch backup state, and are skipped when the diagnosis is ambiguous.
+- Detection of the stale-lock respawn loop. A four-hour lock whose holder is killed by
+  a container restart (or an out-of-memory kill) puts `bztransmit` in a relaunch loop:
+  every few seconds a new pass exits with "Failed to grab fourHourLock", and the
+  constant respawns keep every log and file mtime fresh, so the previous stall
+  heuristics reported a wedged container as healthy. `bb-health` now corroborates by
+  process age instead — a lock older than a small grace window cannot belong to a pass
+  younger than it — and reports the loop as `WEDGE`, so the health status goes red and
+  the watchdog clears it. `bb-doctor` diagnoses the same signature independently of
+  the tunable thresholds, and `bb-doctor --fix` removes the lock only while the full
+  signature holds: a `bztransmit` past the grace window, or one whose age cannot be
+  read, always keeps its lock. CI covers both the detection and the repair gate.
 - `bb-report`, which builds a sanitised diagnostic bundle for a forum post or issue.
   Collection is allowlist-based, so the per-thread XMLs (live auth token, AES key and IV,
   wrapped file encryption key) and the `bz_done` file listings are never included. File

--- a/README.md
+++ b/README.md
@@ -264,12 +264,17 @@ It reports one of:
   Backblaze's automatic thread setting can spin up enough upload threads to deadlock
   Wine's pipe handling, which leaves the transfer stuck forever.
 - `WEDGE` — a stale four-hour lock is blocking every pass. This is what an out-of-memory
-  kill leaves behind: the lock file outlives the process that owned it, and every
-  subsequent pass fails to acquire it.
+  kill or a container restart mid-pass leaves behind: the lock file outlives the process
+  that owned it, and every subsequent pass fails to acquire it. It usually shows as a
+  respawn loop — `bztransmit` is relaunched every few seconds and each attempt exits
+  with "Failed to grab fourHourLock", which keeps every log fresh and hides the fault
+  from any simple staleness test.
 
 Both states are reported only on corroborated evidence — for `WEDGE`, the lock must be
-present *and* stale *and* accompanied by repeated failures in the log *and* no
-`bztransmit` process alive to legitimately own it — so a healthy backup is never flagged.
+present *and* accompanied by repeated failures in the log *and* too old to belong to any
+`bztransmit` still inside its start-up grace window; a pass that has been running longer
+than that window is always assumed to own the lock — so a healthy backup is never
+flagged.
 
 ### Automatic recovery
 
@@ -288,12 +293,13 @@ very slow uplink where more than 20 minutes between transmit-log writes is norma
 | Variable | Meaning | Default |
 |---|---|---|
 |`STALL_MIN`| Minutes the transmit log may be silent (with an upload thread alive) before `HANG` is reported | `20` |
-|`LOCK_AGE_MIN`| Minimum age in minutes of the four-hour lock before it can be considered stale | `245` |
+|`LOCK_AGE_MIN`| Age in minutes past which the four-hour lock is stale even without the failures still being written | `245` |
 |`LOCK_FAILS`| Recent "Failed to grab fourHourLock" log lines required to corroborate a `WEDGE` | `5` |
+|`LOCK_GRACE_MIN`| Minutes a `bztransmit` must have been running before it is assumed to own the lock | `2` |
 |`WATCHDOG_INTERVAL`| Seconds between watchdog health checks | `300` |
 |`COOLDOWN_MIN`| Minutes the watchdog waits after acting before it may act again (raised automatically if set at or below `STALL_MIN`) | `30` |
 
-All five take plain whole numbers; anything else falls back to the default.
+All six take plain whole numbers; anything else falls back to the default.
 
 It is **opt-in** because it deletes a lock file and kills processes, which should be a
 deliberate choice rather than a surprise. Leaving it off costs nothing: the health status

--- a/rootfs/usr/local/bin/bb-doctor
+++ b/rootfs/usr/local/bin/bb-doctor
@@ -52,6 +52,40 @@ proc_match() {
     return 1
 }
 
+# Age of a file in whole minutes, or empty if it cannot be read. Same fail-safe
+# contract as bb-health's copy: a read error yields "" and the caller skips the
+# check rather than inventing a stale age.
+age_min() {
+    mt="$(stat -c %Y "$1" 2>/dev/null)" || return 0
+    case "$mt" in ''|*[!0-9]*) return 0 ;; esac
+    echo $(( ( $(date +%s) - mt ) / 60 ))
+}
+
+# Minutes since the oldest process matching $1 started, or empty when none
+# match. Start times come from the starttime field of /proc/PID/stat measured
+# against /proc/uptime. A start time that cannot be read reports as very old:
+# this decides whether a live bztransmit could own the four-hour lock, and that
+# question must fail toward "it could".
+oldest_proc_min() {
+    up="$(cut -d. -f1 /proc/uptime 2>/dev/null)"
+    tick="$(getconf CLK_TCK 2>/dev/null)"
+    case "$up" in ''|*[!0-9]*) up="" ;; esac
+    case "$tick" in ''|*[!0-9]*) tick=100 ;; esac
+    oldest=""
+    for c in /proc/[0-9]*/cmdline; do
+        [ -r "$c" ] || continue
+        tr '\0' ' ' < "$c" 2>/dev/null | grep -q -- "$1" || continue
+        # starttime is the 20th field after the parenthesised comm, which can
+        # itself contain spaces, so strip through the last ")" first.
+        st="$(sed 's/^.*) //' "${c%/cmdline}/stat" 2>/dev/null | awk '{print $20}')"
+        case "$st" in ''|*[!0-9]*) st="" ;; esac
+        if [ -z "$up" ] || [ -z "$st" ]; then echo 99999; return; fi
+        age=$(( ( up - st / tick ) / 60 ))
+        if [ -z "$oldest" ] || [ "$age" -gt "$oldest" ]; then oldest="$age"; fi
+    done
+    echo "$oldest"
+}
+
 echo "Backblaze container check"
 echo
 
@@ -195,7 +229,39 @@ echo
 echo "Backup health"
 status="$(bb-health 2>/dev/null || true)"
 case "$status" in
-    OK*) OK "no stall detected" ;;
+    OK*)
+        # A stale lock that survives a restart puts bztransmit in a respawn
+        # loop: bzserv relaunches it every few seconds and each attempt dies on
+        # "Failed to grab fourHourLock", so the constant restarts keep every
+        # mtime fresh and a staleness heuristic alone never fires. bb-health
+        # detects this too, but its thresholds are env-tunable, so the
+        # signature is checked here again with fixed ones: the lock present,
+        # failures still being written to today's log, and no bztransmit old
+        # enough to have created the lock (a pass writes its lock only after
+        # it starts, so a 2-minute-old lock cannot belong to younger passes).
+        curlog="${BZ}/bzlogs/bztransmit/bztransmit$(date +%d).log"
+        fails=0
+        if [ -f "$curlog" ]; then
+            la="$(age_min "$curlog")"
+            [ -n "$la" ] && [ "$la" -le 5 ] \
+                && fails="$(tail -60 "$curlog" 2>/dev/null | grep -c "Failed to grab fourHourLock")"
+        fi
+        oldest="$(oldest_proc_min bztransmit)"
+        lock_age=""
+        [ -f "$LOCK" ] && lock_age="$(age_min "$LOCK")"
+        if [ "${fails:-0}" -ge 5 ] && [ -n "$lock_age" ] && [ "$lock_age" -ge 2 ] \
+           && { [ -z "$oldest" ] || [ "$oldest" -lt 2 ]; }; then
+            BAD "stale four-hour lock with bztransmit respawning against it (${fails} recent failures to grab it)"
+            NOTE "the lock outlived its owner - a restart or out-of-memory kill mid-pass -"
+            NOTE "and every new pass exits until it is removed."
+            if [ "$FIX" = 1 ]; then
+                rm -f "$LOCK" 2>/dev/null && FIXED "removed the stale four-hour lock - the next pass should proceed"
+            else
+                NOTE "re-run with --fix to clear the stale lock, or set ENABLE_WATCHDOG=true to handle it automatically."
+            fi
+        else
+            OK "no stall detected"
+        fi ;;
     WEDGE*)
         BAD "$status"
         if [ "$FIX" = 1 ]; then

--- a/rootfs/usr/local/bin/bb-health
+++ b/rootfs/usr/local/bin/bb-health
@@ -12,13 +12,22 @@
 #          logs again.
 #
 #   WEDGE  A stale four-hour lock is blocking every pass. When bztransmit dies
-#          mid-pass, usually an out-of-memory kill on a small host, its lock file
-#          outlives it and bzserv floods the log with "Failed to grab
-#          fourHourLock". Four conditions are required: the lock present, older
-#          than LOCK_AGE_MIN, repeated failures in the log, and no bztransmit
-#          running. A live pass holding the lock is therefore never flagged.
+#          mid-pass - an out-of-memory kill, or a container restart that takes
+#          the lock holder with it - the lock file outlives it and the log
+#          floods with "Failed to grab fourHourLock". Required in every case:
+#          the lock present, repeated failures in the log, and no bztransmit
+#          that has been running for LOCK_GRACE_MIN minutes. A pass writes its
+#          lock only after it starts, so a lock older than the grace window
+#          cannot belong to any process younger than it, and a live holder is
+#          never second-guessed. On top of that, either the lock is older than
+#          LOCK_AGE_MIN, or it is older than LOCK_GRACE_MIN with failures
+#          still being written now. The second form catches the respawn loop:
+#          bzserv relaunches bztransmit every few seconds, each attempt dies
+#          on the lock, and the constant restarts keep every mtime fresh, so
+#          only process age can corroborate it. It is a WEDGE rather than a
+#          HANG because there is nothing to kill, only a lock to remove.
 #
-# Env: STALL_MIN (20), LOCK_AGE_MIN (245), LOCK_FAILS (5).
+# Env: STALL_MIN (20), LOCK_AGE_MIN (245), LOCK_FAILS (5), LOCK_GRACE_MIN (2).
 set -u
 
 usage() {
@@ -52,6 +61,7 @@ LOCK="${BZ}/bzbackup/lock_bzfileid_4_hour_lock.lck"
 STALL_MIN="${STALL_MIN:-20}"
 LOCK_AGE_MIN="${LOCK_AGE_MIN:-245}"     # the lock covers 4h; past that a live holder would have renewed or finished
 LOCK_FAILS="${LOCK_FAILS:-5}"
+LOCK_GRACE_MIN="${LOCK_GRACE_MIN:-2}"   # a pass must have run this long before it is assumed to own the lock
 
 # The thresholds feed arithmetic below and must be plain positive integers. A
 # suffixed value such as "20m" would otherwise fail in a way that reads as a
@@ -60,6 +70,7 @@ int_or() { case "$1" in ''|*[!0-9]*) echo "$2" ;; *) echo "$1" ;; esac; }
 STALL_MIN="$(int_or "$STALL_MIN" 20)"
 LOCK_AGE_MIN="$(int_or "$LOCK_AGE_MIN" 245)"
 LOCK_FAILS="$(int_or "$LOCK_FAILS" 5)"
+LOCK_GRACE_MIN="$(int_or "$LOCK_GRACE_MIN" 2)"
 
 # Match a process by command line without needing procps in the image.
 proc_match() {
@@ -71,6 +82,32 @@ proc_match() {
 }
 
 newest_log() { ls -t "${TLOG}"/*.log 2>/dev/null | head -1; }
+
+# Minutes since the oldest process matching $1 started, or empty when none
+# match. Start times come from the starttime field of /proc/PID/stat measured
+# against /proc/uptime, not from /proc/PID mtimes, which some kernels refresh.
+# A start time that cannot be read reports as very old: the caller uses this to
+# decide whether a live bztransmit could own the lock, and that question must
+# fail toward "it could".
+oldest_proc_min() {
+    up="$(cut -d. -f1 /proc/uptime 2>/dev/null)"
+    tick="$(getconf CLK_TCK 2>/dev/null)"
+    case "$up" in ''|*[!0-9]*) up="" ;; esac
+    case "$tick" in ''|*[!0-9]*) tick=100 ;; esac
+    oldest=""
+    for c in /proc/[0-9]*/cmdline; do
+        [ -r "$c" ] || continue
+        tr '\0' ' ' < "$c" 2>/dev/null | grep -q -- "$1" || continue
+        # starttime is the 20th field after the parenthesised comm, which can
+        # itself contain spaces, so strip through the last ")" first.
+        st="$(sed 's/^.*) //' "${c%/cmdline}/stat" 2>/dev/null | awk '{print $20}')"
+        case "$st" in ''|*[!0-9]*) st="" ;; esac
+        if [ -z "$up" ] || [ -z "$st" ]; then echo 99999; return; fi
+        age=$(( ( up - st / tick ) / 60 ))
+        if [ -z "$oldest" ] || [ "$age" -gt "$oldest" ]; then oldest="$age"; fi
+    done
+    echo "$oldest"
+}
 
 # Age of a file in whole minutes, or empty if it cannot be read. This uses stat
 # and epoch arithmetic rather than find's -newermt date parsing. A stall check has
@@ -96,14 +133,29 @@ if proc_match -threadpush && [ -n "$log" ]; then
 fi
 
 # --- WEDGE: a stale four-hour lock is blocking every pass -------------------------
-if [ -f "$LOCK" ] && ! proc_match bztransmit; then
+if [ -f "$LOCK" ]; then
+    oldest="$(oldest_proc_min bztransmit)"
     lock_age="$(age_min "$LOCK")"
-    if [ -n "$lock_age" ] && [ "$lock_age" -ge "$LOCK_AGE_MIN" ]; then
+    # Nothing to decide unless every live bztransmit is younger than the grace
+    # window: a lock older than the window cannot belong to any of them.
+    if [ -n "$lock_age" ] && { [ -z "$oldest" ] || [ "$oldest" -lt "$LOCK_GRACE_MIN" ]; }; then
         fails=0
         [ -n "$log" ] && fails=$(tail -40 "$log" 2>/dev/null | grep -c "Failed to grab fourHourLock")
         if [ "${fails:-0}" -ge "$LOCK_FAILS" ]; then
-            echo "WEDGE stale four-hour lock, ${fails} recent lock failures, no bztransmit running"
-            exit 1
+            if [ "$lock_age" -ge "$LOCK_AGE_MIN" ]; then
+                echo "WEDGE stale four-hour lock, ${fails} recent lock failures, no bztransmit old enough to own it"
+                exit 1
+            fi
+            # The respawn loop: bzserv relaunches bztransmit every few seconds
+            # and each attempt dies on the lock. The failures must still be
+            # being written now, or a younger-than-LOCK_AGE_MIN lock stays a
+            # live pass's business.
+            log_age="$(age_min "$log")"
+            if [ "$lock_age" -ge "$LOCK_GRACE_MIN" ] \
+               && [ -n "$log_age" ] && [ "$log_age" -le "$LOCK_GRACE_MIN" ]; then
+                echo "WEDGE stale four-hour lock, bztransmit respawning against it (${fails} recent lock failures)"
+                exit 1
+            fi
         fi
     fi
 fi

--- a/rootfs/usr/local/bin/bb-watchdog
+++ b/rootfs/usr/local/bin/bb-watchdog
@@ -5,7 +5,7 @@
 #
 #   WEDGE  Delete the stale four-hour lock so the next pass can start. Lighter
 #          than a container restart, and bb-health has already confirmed no
-#          bztransmit is alive to own the lock.
+#          bztransmit has been running long enough to own the lock.
 #
 #   HANG   Kill the deadlocked push threads. bzserv respawns them, which restarts
 #          the transfer without disturbing the rest of the container. If that does

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Behavioural tests for bb-doctor's stale-lock respawn-loop check, run against a
+# fixture tree.
+#
+# The property under test is the repair gate: "bb-doctor --fix" removes the
+# four-hour lock, and a wrongly removed lock lets a second pass run against
+# backup state a live one still owns. So the lock must go ONLY on the full
+# respawn signature - lock present, grab failures still being written to
+# today's log, and no bztransmit old enough to have created the lock - and any
+# unreadable input must read as "keep the lock".
+#
+# Run:  bash tests/test-doctor.sh
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SRC="$HERE/../rootfs/usr/local/bin/bb-doctor"
+FX="$(mktemp -d)"; trap 'rm -rf "$FX"' EXIT
+PFX="$FX/config/wine/"
+BZ="${PFX}dosdevices/c:/ProgramData/Backblaze/bzdata"
+mkdir -p "$BZ/bzlogs/bztransmit" "$BZ/bzbackup" "${PFX}drive_c" "$FX/proc" "$FX/bin"
+LOGCUR="$BZ/bzlogs/bztransmit/bztransmit$(date +%d).log"
+LOCK="$BZ/bzbackup/lock_bzfileid_4_hour_lock.lck"
+
+# Point the script's /proc scans at the fixture; the data paths follow from
+# WINEPREFIX. Stub the two external commands: bb-health answers OK so the
+# doctor's own check is what decides, and curl answers reachable instantly.
+sed -e "s#/proc/\[0-9\]\*/cmdline#$FX/proc/[0-9]*/cmdline#g" \
+    -e "s#/proc/uptime#$FX/proc/uptime#g" \
+    "$SRC" > "$FX/bb-doctor"
+chmod +x "$FX/bb-doctor"
+printf '#!/bin/sh\necho OK\n' > "$FX/bin/bb-health"
+printf '#!/bin/sh\nexit 0\n' > "$FX/bin/curl"
+chmod +x "$FX/bin/bb-health" "$FX/bin/curl"
+# On macOS (dev laptops) stat -c is BSD stat, so shim GNU-style stat -c %Y.
+if ! stat -c %Y "$FX" >/dev/null 2>&1; then
+    cat > "$FX/bin/stat" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "-c" ] && [ "$2" = "%Y" ]; then
+    perl -e 'my @s=stat($ARGV[0]) or exit 1; print $s[9],"\n"' "$3"
+else
+    exec /usr/bin/stat "$@"
+fi
+EOF
+    chmod +x "$FX/bin/stat"
+fi
+
+FAILED=0
+UP=8000000   # fixture /proc/uptime, seconds since boot
+has(){ if grep -q "$2" <<<"$1"; then echo "PASS $3"; else echo "FAIL $3 (missing '$2')"; FAILED=$((FAILED+1)); fi; }
+locked(){ if [ -f "$LOCK" ]; then echo "PASS $1"; else echo "FAIL $1 (lock was removed)"; FAILED=$((FAILED+1)); fi; }
+unlocked(){ if [ -f "$LOCK" ]; then echo "FAIL $1 (lock still present)"; FAILED=$((FAILED+1)); else echo "PASS $1"; fi; }
+mkproc(){ rm -rf "$FX/proc"; mkdir -p "$FX/proc"; echo "$UP.00 $UP.00" > "$FX/proc/uptime"; local pid=100
+  for cmd in "$@"; do mkdir -p "$FX/proc/$pid"; printf '%s' "$cmd" | tr ' ' '\0' > "$FX/proc/$pid/cmdline"; pid=$((pid+1)); done; }
+# Give /proc/PID a stat file making the process AGE_S seconds old (starttime is
+# the 20th field after the comm). mkproc assigns pids from 100 in argument
+# order. Without a stat file the process age is unreadable, and the doctor must
+# treat it as old enough to own the lock (fail safe).
+procage(){ printf '%s (bztransmit.exe) S 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 %s 0\n' \
+  "$1" $(( (UP - $2) * 100 )) > "$FX/proc/$1/stat"; }
+agef(){ perl -e 'my $t=time-$ARGV[1]; utime $t,$t,$ARGV[0]' "$1" "$2"; }
+spam(){ for i in $(seq 1 "$1"); do echo "10:00:0$i - Failed to grab fourHourLock lock (DoBackupPass.cpp:111)"; done; }
+run(){ env WINEPREFIX="$PFX" PATH="$FX/bin:$PATH" "$FX/bb-doctor" "$@" 2>/dev/null; }
+
+# The full wedge signature: a 30-minute lock nothing live created, grab
+# failures being written to today's log right now, and only a seconds-old
+# bztransmit alive (the respawn loop).
+wedge(){ mkproc "bzserv.exe" "bztransmit.exe -doBackupPass"; procage 101 5
+  touch "$LOCK"; agef "$LOCK" 1800; spam 8 > "$LOGCUR"; }
+
+# 1. the full signature is reported as a problem, and without --fix nothing moves
+wedge
+out="$(run)"
+has "$out" "bztransmit respawning against it" "respawn wedge is reported as a problem"
+locked "without --fix the lock is untouched"
+
+# 2. --fix removes the lock on the full signature
+wedge
+out="$(run --fix)"
+has "$out" "removed the stale four-hour lock" "--fix reports the removal"
+unlocked "--fix removes the stale lock"
+
+# 3. a bztransmit older than the grace window may own the lock: keep it
+wedge; procage 101 600
+out="$(run --fix)"
+has "$out" "no stall detected" "long-running bztransmit reads as healthy here"
+locked "--fix keeps a lock a long-running bztransmit may own"
+
+# 4. FAIL-SAFE: an unreadable start time counts as long-running
+wedge; rm "$FX/proc/101/stat"
+run --fix >/dev/null
+locked "--fix keeps the lock when the process age is unreadable"
+
+# 5. no grab failures in today's log: not a wedge, whatever the lock's age
+wedge; echo "10:00:01 - normal transmit line" > "$LOGCUR"
+run --fix >/dev/null
+locked "--fix keeps the lock without fresh grab failures"
+
+# 6. failures that stopped minutes ago are not a live respawn loop
+wedge; agef "$LOGCUR" 900
+run --fix >/dev/null
+locked "--fix keeps the lock when the failures are no longer being written"
+
+# 7. a lock younger than the grace window may belong to the pass that just
+#    started: keep it
+wedge; touch "$LOCK"
+run --fix >/dev/null
+locked "--fix keeps a lock younger than the grace window"
+
+echo
+echo "$FAILED failures"
+exit $(( FAILED > 0 ? 1 : 0 ))

--- a/tests/test-health.sh
+++ b/tests/test-health.sh
@@ -21,6 +21,7 @@ LOCK="$BZ/bzbackup/lock_bzfileid_4_hour_lock.lck"
 # stat, so shim GNU-style stat -c %Y via perl if needed.
 sed -e "s#^BZ=\"/config#BZ=\"$FX/config#" \
     -e "s#/proc/\[0-9\]\*/cmdline#$FX/proc/[0-9]*/cmdline#g" \
+    -e "s#/proc/uptime#$FX/proc/uptime#g" \
     "$SRC" > "$FX/bb-health"
 chmod +x "$FX/bb-health"
 if ! stat -c %Y "$FX" >/dev/null 2>&1; then
@@ -38,11 +39,21 @@ EOF
 fi
 
 FAILED=0
+UP=8000000   # fixture /proc/uptime, seconds since boot
 ok(){ if [ "$1" = "$2" ]; then echo "PASS $3"; else echo "FAIL $3 (want '$1' got '$2')"; FAILED=$((FAILED+1)); fi; }
-mkproc(){ rm -rf "$FX/proc"; mkdir -p "$FX/proc"; local pid=100
+mkproc(){ rm -rf "$FX/proc"; mkdir -p "$FX/proc"; echo "$UP.00 $UP.00" > "$FX/proc/uptime"; local pid=100
   for cmd in "$@"; do mkdir -p "$FX/proc/$pid"; printf '%s' "$cmd" | tr ' ' '\0' > "$FX/proc/$pid/cmdline"; pid=$((pid+1)); done; }
+# Give /proc/PID a stat file making the process AGE_S seconds old (starttime is
+# the 20th field after the comm). mkproc assigns pids from 100 in argument
+# order. Without a stat file the process age is unreadable, and bb-health must
+# treat it as old enough to own the lock (fail safe).
+procage(){ printf '%s (bztransmit.exe) S 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 %s 0\n' \
+  "$1" $(( (UP - $2) * 100 )) > "$FX/proc/$1/stat"; }
 run(){ env "$@" "$FX/bb-health" 2>/dev/null | awk '{print $1}'; }
 old(){ touch -t 202601010000 "$1"; }
+# Set a file's mtime to AGE_S seconds ago (touch -t cannot express a relative
+# age portably; perl is already a dependency of the stat shim above).
+agef(){ perl -e 'my $t=time-$ARGV[1]; utime $t,$t,$ARGV[0]' "$1" "$2"; }
 spam(){ for i in $(seq 1 "$1"); do echo "2026-07-05 10:00:0$i Failed to grab fourHourLock"; done; }
 
 # 1. empty container is healthy
@@ -97,6 +108,34 @@ ok "OK" "$(run)" "fresh lock is not a wedge"
 # 10. old lock without spam is not a wedge
 old "$LOCK"; : > "$LOGF"
 ok "OK" "$(run)" "old lock without failure spam is not a wedge"
+
+# 11. WEDGE via the respawn loop: the lock survived a restart, bzserv relaunches
+#     bztransmit every few seconds and each attempt dies on it. Every mtime is
+#     fresh and the lock is younger than LOCK_AGE_MIN, so only the process age
+#     can corroborate: a 30-minute lock cannot belong to a 5-second pass.
+mkproc "bzserv.exe" "bztransmit.exe -doBackupPass"; procage 101 5
+touch "$LOCK"; agef "$LOCK" 1800; spam 8 > "$LOGF"
+ok "WEDGE" "$(run)" "respawn loop against a restart-surviving lock = WEDGE"
+
+# 12. same signature, but the pass has been running longer than the grace
+#     window: it is never second-guessed, even though the lock predates it
+procage 101 600
+ok "OK" "$(run)" "bztransmit older than the grace window is assumed to own the lock"
+
+# 13. FAIL-SAFE: an unreadable process start time must read as "old enough to
+#     own the lock", never as a removable wedge
+rm "$FX/proc/101/stat"
+ok "OK" "$(run)" "unreadable bztransmit start time fails SAFE (no wedge verdict)"
+
+# 14. a lock younger than the grace window may have just been created by the
+#     young pass that is now writing: not a wedge
+procage 101 5; touch "$LOCK"
+ok "OK" "$(run)" "fresh lock beside a young pass is not a wedge"
+
+# 15. past LOCK_AGE_MIN the seconds-old respawns must not mask the wedge the
+#     way "any bztransmit alive" used to
+old "$LOCK"
+ok "WEDGE" "$(run)" "old lock + failure spam + only seconds-old respawns = WEDGE"
 
 echo
 echo "$FAILED failures"


### PR DESCRIPTION
## The problem

bb-doctor reported "14 ok, 0 problems" and "no stall detected" on a genuinely wedged container. A stale `lock_bzfileid_4_hour_lock.lck` had survived a docker restart that killed the lock holder, and bztransmit was respawning every ~5 seconds, each pass exiting with "Failed to grab fourHourLock" (DoBackupPass.cpp:111). The constant respawns keep every log and file mtime fresh, so the existing mtime-based stall heuristics could never fire: `HANG` needs a silent log, and `WEDGE` needed *no* bztransmit alive plus a >245-minute lock.

## The fix

**bb-health** now corroborates `WEDGE` by **process age** instead of process absence: start times are read from `/proc/PID/stat` against `/proc/uptime`, and a lock older than a small grace window (`LOCK_GRACE_MIN`, default 2) cannot belong to any pass younger than it, since a pass writes its lock only after it starts. The respawn loop is reported as `WEDGE` — not `HANG` — because the recovery that clears it is removing the lock; there are no long-lived push threads to kill. The health status now goes unhealthy and the watchdog's existing WEDGE path clears it.

**bb-doctor** checks the same signature independently of the tunable thresholds: lock present, repeated grab failures still being written to today's `bztransmitDD.log`, and no bztransmit older than a couple of minutes. `--fix` removes the lock only while the full signature holds — a bztransmit past the grace window, or one whose age cannot be read, always keeps its lock.

## Fail-safe properties

- An unreadable process start time reads as "old enough to own the lock", never as a removable wedge.
- A lock younger than the grace window is never touched: the pass that just started may have created it.
- A pass older than the grace window is never second-guessed, even when the lock predates it.

## Tests

- `tests/test-health.sh`: five new cases (respawn loop → WEDGE, grace-window ownership, unreadable start time fails safe, fresh lock spared, old-lock path no longer masked by seconds-old respawns), with fixture support for process ages.
- `tests/test-doctor.sh` (new): seven assertions on the repair gate, run against a fixture tree with bb-health and curl stubbed.
- Both wired into the CI gate job before any image builds.